### PR TITLE
fix(security): Removed webhook APIs that exposed webhook secrets

### DIFF
--- a/server/team/team.route.js
+++ b/server/team/team.route.js
@@ -21,15 +21,6 @@ router
   .post(ifNoUserRedirect(), ifNoBody400, validate(validators.createTeam), teamCtrl.update);
 
 router
-  .route('/webhooks/:teamId')
-  .get(teamCtrl.viewWebhooks)
-  .post(teamCtrl.newWebhooks);
-
-router
-  .route('/analyze/:teamId')
-  .get(teamCtrl.analyze);
-
-router
   .route('/delete/:teamId')
   .post(ifNoUserRedirect(), ifNotOwnTeam400, teamCtrl.deleteTeam);
 

--- a/server/team/team.test.js
+++ b/server/team/team.test.js
@@ -13,7 +13,7 @@ chai.use(sinonChai);
 
 const team = {
   name: 'freeCodeCamp',
-  collaborators: 'Bouncey, raisedadead',
+  collaborators: ['Bouncey', '@raisedadead'],
   githubRepository: 'https://github.com/freeCodeCamp/freeeCodeCamp',
   siteUrl: 'https://www.freecodecamp.org',
   isOnlineHackathon: true
@@ -48,7 +48,7 @@ describe('# Team API', () => {
       Webhook.create.restore();
     });
 
-    it('should call `create` on the Team model', () => {
+    it('should call `create` on the Team model', (done) => {
       const { create } = teamCtrl;
       const request = {
         body: team,
@@ -57,16 +57,18 @@ describe('# Team API', () => {
       const req = mockReq(request);
       const res = mockRes();
 
-      create(req, res).then(() => {
-        expect(Team.create).to.be.calledWith({
-          ...team,
-          collaborators: ['Bouncey', 'raisedadead']
-        });
-      });
+      create(req, res)
+        .then(() => {
+          expect(Team.create).to.be.calledWith({
+            ...team,
+            collaborators: ['Bouncey', 'raisedadead']
+          });
+          done();
+        })
+        .catch(done);
     });
-    /*
     it('should call `update` on the User model with the team id', (done) => {
-      const { update } = teamCtrl;
+      const { create } = teamCtrl;
       const request = {
         body: team,
         user
@@ -74,12 +76,13 @@ describe('# Team API', () => {
       const req = mockReq(request);
       const res = mockRes();
 
-      update(req, res).then(() => {
-        expect(User.update).to.be.calledWith(user, { teamId: newTeam._id });
-        done();
-      });
+      create(req, res)
+        .then(() => {
+          expect(User.update).to.be.calledWith(user, { teamId: newTeam._id });
+          done();
+        })
+        .catch(done);
     });
-    */
     it('should acknowledge a successful team creation', (done) => {
       const { create } = teamCtrl;
       const request = {
@@ -89,12 +92,14 @@ describe('# Team API', () => {
       const req = mockReq(request);
       const res = mockRes();
 
-      create(req, res).then(() => {
-        const jsonCalledWith = res.json.getCalls()[0].args[0];
+      create(req, res)
+        .then(() => {
+          const jsonCalledWith = res.json.getCalls()[0].args[0];
 
-        expect(jsonCalledWith.acknowledged).to.equal(true);
-        done();
-      });
+          expect(jsonCalledWith.acknowledged).to.equal(true);
+          done();
+        })
+        .catch(done);
     });
 
     it('should acknowledge a failed attempt at creating a team', (done) => {
@@ -115,12 +120,14 @@ describe('# Team API', () => {
       const req = mockReq(request);
       const res = mockRes();
 
-      create(req, res).then(() => {
-        expect(res.status).to.be.calledWith(500);
-        expect(res.json).to.be.calledWith({ acknowledged: false });
-        expect(User.update.called).to.equal(false);
-        done();
-      });
+      create(req, res)
+        .then(() => {
+          expect(res.status).to.be.calledWith(500);
+          expect(res.json).to.be.calledWith({ acknowledged: false });
+          expect(User.update.called).to.equal(false);
+          done();
+        })
+        .catch(done);
     });
 
     it('should not call User.update if the request throws', (done) => {
@@ -142,15 +149,17 @@ describe('# Team API', () => {
       const res = mockRes();
       const next = sinon.spy();
 
-      create(req, res, next).then(() => {
-        expect(User.update.called).to.equal(false);
-        expect(next.calledOnce).to.equal(true);
-        done();
-      });
+      create(req, res, next)
+        .then(() => {
+          expect(User.update.called).to.equal(false);
+          expect(next.calledOnce).to.equal(true);
+          done();
+        })
+        .catch(done);
     });
-    /*
+
     it('creates two new webhooks', (done) => {
-      const { newWebhooks } = teamCtrl;
+      const { create } = teamCtrl;
       const request = {
         body: team,
         user
@@ -159,11 +168,12 @@ describe('# Team API', () => {
       const req = mockReq(request);
       const res = mockRes();
 
-      newWebhooks(req, res).then(() => {
-        expect(Webhook.create.calledTwice).to.equal(true);
-        done();
-      });
+      create(req, res)
+        .then(() => {
+          expect(Webhook.create.calledTwice).to.equal(true);
+          done();
+        })
+        .catch(done);
     });
-    */
   });
 });

--- a/server/views/layout.pug
+++ b/server/views/layout.pug
@@ -12,7 +12,7 @@ html(lang='en')
         data: function data() { return {
             teams: this.parseArr(!{JSON.stringify(teams)}),
             team: this.parseObj(!{JSON.stringify(team)}),
-            webhooks: '',
+            webhooks: this.parseObj(!{JSON.stringify(webhooks)}),
             checked: false,
             picked:
             (this.parseObj(!{JSON.stringify(team)}) !== '' ?
@@ -44,9 +44,6 @@ html(lang='en')
             self.getTeams();
             self.startTeamsPolling();
             self.sortBy('lighthouse', true);
-          }
-          if (self.team && self.team !== '' && self.team !== ['']) {
-            self.renderWebhooks();
           }
         },
         beforeDestroy() {
@@ -185,30 +182,12 @@ html(lang='en')
               if (parseInt(status, 10) === 200) {
                 self.createFlash('success', 'Your team has been '+msg+'ed!<br><br>');
                 if (msg === 'creat') {
-                  axios.post(`/api/teams/webhooks/${response.data.teamId}`)
-                  .then(() => {
-                    return window.location.href = '/team';
-                  })
-                  .catch(function(error){
-                    console.error(error);
-                    return self.createFlash('danger', 'Something went wrong '+msg+'ing your team, more info in the console')
-                  })
+                  setTimeout(function() {window.location.href = '/team';}, 1000 * 60 * 3) // three seconds
                 }
 
               } else {
                 return self.createFlash('warning', 'Something went wrong '+msg+'ing your team')
               }
-            })
-          },
-          renderWebhooks() {
-            var self = this;
-            if (self.webhooks) {
-              console.log(self.webhooks)
-            }
-            axios.get(`/api/teams/webhooks/${self.team._id}`)
-            .then(function(result) {
-              console.log(result.data.webhook)
-              self.webhooks = result.data.webhook;
             })
           },
           removeTeam() {

--- a/server/views/partials/viewWebhooks.pug
+++ b/server/views/partials/viewWebhooks.pug
@@ -1,4 +1,4 @@
-div(v-if="webhooks && webhooks !== ''") #{JSON.stringify(webhooks, null, 2)}
+div(v-if="webhooks && webhooks !== ''")
   div.webhook-display
     h5.webhook-title(v-text="webhooks.name + ' Webhook'")
     pre


### PR DESCRIPTION
Secrets of any kind should never be readable from an API, because then they are not secret any more.

This PR reimplements and fixes some tests that were broken due to the exposing or the webhooks via API call.